### PR TITLE
Add build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM codingame/rust:1.15
 COPY build.sh      /project/build
 COPY entrypoint.sh /
 
-RUN chmod +x /project/build entrypoint.sh
+RUN chmod +x /project/build /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM codingame/rust:1.15
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		rsync \
-	&& rm -rf /var/lib/apt/lists/*
-
+COPY build.sh      /project/build
 COPY entrypoint.sh /
 
-RUN chmod +x entrypoint.sh
+RUN chmod +x /project/build entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # rust-cargo-runner
 
-This is a Rust 1.15 runner that executes tests thanks to the `cargo test` command.
+This is a Rust 1.15 runner that:
+- builds the project once using `cargo build` (i.e. fetches dependencies and compiles initial source files)
+- executes tests thanks to the `cargo test` command.
 
 ## How to Use
 
@@ -9,7 +11,7 @@ In order to use this runner for your project, edit the `codingame.yml` file and 
 ```yaml
     runner:
       name: codingame/rust-cargo-runner
-      version: 1.15
+      version: 1.0-rust-1.15
 ```
 
 ## Example
@@ -46,9 +48,3 @@ In the markdown file, the unit test can be called using:
 ```markdown
 @[Test uppercase]({"stubs":["uppercase.rs"], "command":"string_tests::test_to_upper"})
 ```
-
-## Compatibility
-
-If a Cargo project is detected, the runner will use it to execute the project.
-
-Compatible with `rust-cargo-builder`.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd /project/target
+
+# Fetch dependencies
+cargo build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 
-# Copy cargo registry
-[ -d /project/target/.cargo ] && \
-	rsync -a /project/target/.cargo/ ~/.cargo
-
 # Copy answer code
-cp -a /project/answer/* /project/target/source/
+cp -a /project/answer/* /project/target
 
-cd /project/target/source
+cd /project/target
 
+# Run the given testcase(s)
 cargo build -q && cargo test -q --lib $@


### PR DESCRIPTION
Use a `build.sh` script instead of a builder, since both are strongly coupled.